### PR TITLE
Add simple React site with CDK deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# personal
+# Personal Website
+
+This repository contains a simple personal website built with React and a sample AWS CDK app to deploy it to an S3 bucket fronted by CloudFront.
+
+## Site
+
+The site is located in the `site/` directory. It uses React from a CDN and supports dark mode out of the box via the `prefers-color-scheme` media query.
+
+To test locally, open `site/index.html` in a browser. Edit `js/main.js` to change the name, links, CV and project information.
+
+## CDK Deployment
+
+The CDK application lives in the `cdk/` directory and creates:
+
+- an S3 bucket for static hosting,
+- a CloudFront distribution serving content from the bucket,
+- a deployment step that uploads the files from `site/` to the bucket and invalidates the distribution.
+
+### Prerequisites
+
+Install dependencies (requires internet access):
+
+```bash
+cd cdk
+npm install
+```
+
+Bootstrap your environment and deploy:
+
+```bash
+npx cdk bootstrap
+npx cdk deploy
+```
+
+The output will include the CloudFront distribution domain where the website will be hosted.

--- a/cdk/bin/personal-site.js
+++ b/cdk/bin/personal-site.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const cdk = require('aws-cdk-lib');
+const { PersonalSiteStack } = require('../lib/personal-site-stack');
+
+const app = new cdk.App();
+new PersonalSiteStack(app, 'PersonalSiteStack', {});

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/personal-site.js"
+}

--- a/cdk/lib/personal-site-stack.js
+++ b/cdk/lib/personal-site-stack.js
@@ -1,0 +1,42 @@
+const cdk = require('aws-cdk-lib');
+const { Bucket, BucketAccessControl } = require('aws-cdk-lib/aws-s3');
+const { CloudFrontWebDistribution, OriginAccessIdentity } = require('aws-cdk-lib/aws-cloudfront');
+const { S3Origin } = require('aws-cdk-lib/aws-cloudfront-origins');
+const { BucketDeployment, Source } = require('aws-cdk-lib/aws-s3-deployment');
+const path = require('path');
+
+class PersonalSiteStack extends cdk.Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    const siteBucket = new Bucket(this, 'SiteBucket', {
+      accessControl: BucketAccessControl.PRIVATE,
+      websiteIndexDocument: 'index.html',
+      websiteErrorDocument: 'index.html'
+    });
+
+    const oai = new OriginAccessIdentity(this, 'OAI');
+    siteBucket.grantRead(oai);
+
+    const distribution = new CloudFrontWebDistribution(this, 'SiteDistribution', {
+      originConfigs: [
+        {
+          s3OriginSource: {
+            s3BucketSource: siteBucket,
+            originAccessIdentity: oai
+          },
+          behaviors: [{ isDefaultBehavior: true }]
+        }
+      ]
+    });
+
+    new BucketDeployment(this, 'DeployWebsite', {
+      sources: [Source.asset(path.join(__dirname, '../../site'))],
+      destinationBucket: siteBucket,
+      distribution,
+      distributionPaths: ['/*']
+    });
+  }
+}
+
+module.exports = { PersonalSiteStack };

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "personal-site-cdk",
+  "version": "1.0.0",
+  "bin": {
+    "cdk": "bin/personal-site.js"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.142.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1,0 +1,44 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #ffffff;
+  color: #333333;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #121212;
+    color: #ffffff;
+  }
+}
+
+header {
+  text-align: center;
+  padding: 2rem 0;
+}
+
+header img {
+  border-radius: 50%;
+  width: 150px;
+  height: 150px;
+}
+
+.links a {
+  margin: 0 0.5rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.section {
+  margin: 1rem auto;
+  width: 90%;
+  max-width: 600px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 1rem;
+}
+
+.section h2 {
+  margin-top: 0;
+  cursor: pointer;
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My Personal Website</title>
+  <link rel="stylesheet" href="css/style.css">
+  <!-- React from CDN -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/@mui/material@latest/umd/material-ui.production.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -1,0 +1,37 @@
+const { useState } = React;
+
+function Section({ title, children }) {
+  const [open, setOpen] = useState(false);
+  return (
+    React.createElement('div', { className: 'section' },
+      React.createElement('h2', { onClick: () => setOpen(!open) }, title),
+      open && React.createElement('div', null, children)
+    )
+  );
+}
+
+function App() {
+  return (
+    React.createElement('div', null,
+      React.createElement('header', null,
+        React.createElement('h1', null, 'John Doe'),
+        React.createElement('img', { src: 'photo.jpg', alt: 'Profile photo' }),
+        React.createElement('div', { className: 'links' },
+          React.createElement('a', { href: 'https://github.com/' }, 'GitHub'),
+          React.createElement('a', { href: 'https://www.linkedin.com/' }, 'LinkedIn')
+        )
+      ),
+      React.createElement(Section, { title: 'Curriculum Vitae' },
+        React.createElement('p', null, 'Add your CV details here.')
+      ),
+      React.createElement(Section, { title: 'Projects' },
+        React.createElement('ul', null,
+          React.createElement('li', null, 'Project A'),
+          React.createElement('li', null, 'Project B')
+        )
+      )
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));


### PR DESCRIPTION
## Summary
- build minimal React site with dark mode
- add AWS CDK setup for CloudFront deployment
- document how to deploy the site

## Testing
- `npm test --silent`
- `node cdk/bin/personal-site.js` *(fails: Cannot find module 'aws-cdk-lib')*

------
https://chatgpt.com/codex/tasks/task_b_687b7f7da5808332b8b9f4545487b3e2